### PR TITLE
DOI-768 npm package publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Publish packages
 on:
   push:
     branches:
-      - 'DOI-768-*'
+      - 'master'
 
 jobs:
   cancel-previous:

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 
   },
   "release": {
-    "branch": "DOI-768-*",
+    "branches": "master",
     "plugins": [
         "@semantic-release/commit-analyzer",
         "@semantic-release/release-notes-generator",


### PR DESCRIPTION
- CI setup to publish `@eneveryweb/iam-contracts` package to npm registry.
- Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) from SemVer to automatically add versioning of the package.
  - `git commit -m "fix() Fixed bug on foo"`
  - `git commit -m "feat(sematic release) DOI-768 setup ci to publish package in npm"`
  - `git commit -m "chore() remove EnsRegistryImport.sol as not needed "`

fix — to indicate a bug fix (PATCH) ex . v0.0.1
feat — to indicate a new feature (MINOR) ex. v0.1.0
chore — for updates that do not require a version bump (.gitignore, comments, etc.)
docs — for updates to the documentation
BREAKING CHANGE — regardless of type, indicates a Major release (MAJOR) ex. v1.0.0