### PR TITLE
feat(EnrolementPrequisiteRolesResolver): add mustHaveAll boolean

### DIFF
--- a/src/DomainReader.ts
+++ b/src/DomainReader.ts
@@ -65,7 +65,7 @@ export class DomainReader {
       try {
         definition = JSON.parse(textData, this.reviveDates) as IRoleDefinition | IAppDefinition | IOrganizationDefinition;
       } catch (err) {
-        throw Error(`unable to parse resolved textData for node: ${node}. ${JSON.stringify(err)}`)
+        throw Error(`unable to parse resolved textData for node: ${node}. textData: ${textData}. error: ${JSON.stringify(err)}`)
       }
       return definition
     }
@@ -76,7 +76,7 @@ export class DomainReader {
       try {
         textProps = JSON.parse(textData, this.reviveDates) as IRoleDefinitionText | IAppDefinition | IOrganizationDefinition;
       } catch (err) {
-        throw Error(`unable to parse resolved textData for node: ${node}. ${JSON.stringify(err)}`)
+        throw Error(`unable to parse resolved textData for node: ${node}. textData: ${textData}. error: ${JSON.stringify(err)}`)
       }
 
       if (DomainReader.isOrgDefinition(textProps) || DomainReader.isAppDefinition(textProps)) {
@@ -137,8 +137,8 @@ export class DomainReader {
       issuer = {}
     }
 
-    const prerequisiteRoleNodes = await ensResolver.prerequisiteRoles(node)
-    const prerequisiteRoles = await Promise.all(prerequisiteRoleNodes.map(node => ensResolver.name(node)))
+    const prerequisiteRolesNodes = await ensResolver.prerequisiteRoles(node)
+    const prerequisiteRoles = await Promise.all(prerequisiteRolesNodes[0].map(node => ensResolver.name(node)))
     const enrolmentPreconditions = prerequisiteRoles.length >= 1
       ? [{ type: PreconditionType.Role, conditions: prerequisiteRoles }]
       : []

--- a/src/DomainTransactionFactory.ts
+++ b/src/DomainTransactionFactory.ts
@@ -236,7 +236,8 @@ export class DomainTransactionFactory {
       to: this.roleDefinitionResolver.address,
       data: this.roleDefinitionResolver.interface.functions.setPrerequisiteRoles.encode([
         namehash(domain),
-        prequisiteRoleDomains
+        prequisiteRoleDomains,
+        false // mustHaveAll = false so only need to have one of the set
       ])
     };
   }

--- a/test/RoleDefinitionResolver.testSuite.ts
+++ b/test/RoleDefinitionResolver.testSuite.ts
@@ -235,19 +235,23 @@ export function roleDefinitionResolverTestSuite(): void {
   describe('enrolmentPrerequisiteRoles', async () => {
     it('permits setting prerequisite roles by owner', async () => {
       const initialRoles = await roleDefinitionResolver.prerequisiteRoles(roleNode);
-      expect(initialRoles).to.be.empty;
+      expect(initialRoles[0]).to.be.empty; // role names array should be empty
+      expect(initialRoles[1]).to.be.false; // mustHaveAll should be false 
       const newRoles = [utils.namehash("anotherRole.iam.ewc")];
-      const tx = await roleDefinitionResolver.setPrerequisiteRoles(roleNode, newRoles);
+      const mustHaveAll = true;
+      const tx = await roleDefinitionResolver.setPrerequisiteRoles(roleNode, newRoles, mustHaveAll);
       const changedRoles = await roleDefinitionResolver.prerequisiteRoles(roleNode);
-      expect(changedRoles).to.eql(newRoles);
+      expect(changedRoles[0]).to.eql(newRoles);
+      expect(changedRoles[1]).to.eql(mustHaveAll);
 
       const event = await getTransactionEventArgs(tx);
-      expect(event.args?.newPrerequisiteRoles).to.eql(newRoles);
+      expect(event.args?.newPrerequisiteRoles?.[0]).to.eql(newRoles);
+      expect(event.args?.newPrerequisiteRoles?.[1]).to.eql(mustHaveAll);
       expect(event.args?.node).to.equal(roleNode);
     });
 
     it('prevents updating prerequisite roles by non-owner', async () => {
-      await expect(roleDefinitionResolver.connect(anotherAccount).setPrerequisiteRoles(roleNode, [])).to.eventually.be.rejected;
+      await expect(roleDefinitionResolver.connect(anotherAccount).setPrerequisiteRoles(roleNode, [], false)).to.eventually.be.rejected;
     });
   });
 


### PR DESCRIPTION
This is to allow flexibility in how the prerequisites are defined. If `mustHaveAll == true` then the requester must have all of the prerequisite roles. If `mustHaveAll == false` then they only need to have one.