### PR TITLE
fix(DomainHierarchy): removing empty string from single level

### DIFF
--- a/src/DomainHierarchy.ts
+++ b/src/DomainHierarchy.ts
@@ -109,7 +109,7 @@ export class DomainHierarchy {
       },
       provider: this._ensRegistry.provider
     });
-    return [...singleLevel]
+    return [...singleLevel].filter(Boolean); // Boolean filter to remove empty string
   };
 
   /**


### PR DESCRIPTION
Was already being done in the other return statements in the class