### PR TITLE
feat: exporting contracts types in an ethers-v4 dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,13 +66,13 @@ common/autoinstallers/*/.npmrc
 
 # Hardhat files
 cache
-typechain
+ethers-v4
 
 # VS Code files
 .vscode
 
 # Build outputs
 dist
-typechain
+ethers-v4
 build/contracts
 bin/contracts

--- a/package-lock.json
+++ b/package-lock.json
@@ -12696,7 +12696,7 @@
       "dependencies": {
         "@types/bn.js": {
           "version": "4.11.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
           "dev": true,
           "requires": {
@@ -12705,13 +12705,13 @@
         },
         "@types/node": {
           "version": "14.11.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
           "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
           "dev": true
         },
         "@types/pbkdf2": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
           "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
           "dev": true,
           "requires": {
@@ -12720,7 +12720,7 @@
         },
         "@types/secp256k1": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
           "integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
           "dev": true,
           "requires": {
@@ -12729,13 +12729,13 @@
         },
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -12744,7 +12744,7 @@
         },
         "base-x": {
           "version": "3.0.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
           "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
           "dev": true,
           "requires": {
@@ -12753,25 +12753,25 @@
         },
         "blakejs": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
           "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U=",
           "dev": true
         },
         "bn.js": {
           "version": "4.11.9",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         },
         "brorand": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
           "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
           "dev": true
         },
         "browserify-aes": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
           "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
           "dev": true,
           "requires": {
@@ -12785,7 +12785,7 @@
         },
         "bs58": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
           "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
           "dev": true,
           "requires": {
@@ -12794,7 +12794,7 @@
         },
         "bs58check": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
           "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
           "dev": true,
           "requires": {
@@ -12805,25 +12805,25 @@
         },
         "buffer-from": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
           "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
           "dev": true
         },
         "buffer-xor": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
           "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
           "dev": true
         },
         "camelcase": {
           "version": "5.3.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true
         },
         "cipher-base": {
           "version": "1.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
           "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
           "dev": true,
           "requires": {
@@ -12833,7 +12833,7 @@
         },
         "cliui": {
           "version": "5.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
           "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "dev": true,
           "requires": {
@@ -12844,7 +12844,7 @@
         },
         "color-convert": {
           "version": "1.9.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
           "dev": true,
           "requires": {
@@ -12853,13 +12853,13 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
         "create-hash": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
           "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
           "dev": true,
           "requires": {
@@ -12872,7 +12872,7 @@
         },
         "create-hmac": {
           "version": "1.1.7",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
           "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
           "dev": true,
           "requires": {
@@ -12886,7 +12886,7 @@
         },
         "cross-spawn": {
           "version": "6.0.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
@@ -12899,13 +12899,13 @@
         },
         "decamelize": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "elliptic": {
           "version": "6.5.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
           "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
           "dev": true,
           "requires": {
@@ -12920,13 +12920,13 @@
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
         "end-of-stream": {
           "version": "1.4.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
           "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
           "dev": true,
           "requires": {
@@ -12935,7 +12935,7 @@
         },
         "ethereum-cryptography": {
           "version": "0.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
           "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
           "dev": true,
           "requires": {
@@ -12958,7 +12958,7 @@
         },
         "ethereumjs-util": {
           "version": "6.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
           "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
           "dev": true,
           "requires": {
@@ -12973,7 +12973,7 @@
         },
         "ethjs-util": {
           "version": "0.1.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
           "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
           "dev": true,
           "requires": {
@@ -12983,7 +12983,7 @@
         },
         "evp_bytestokey": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
           "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
           "dev": true,
           "requires": {
@@ -12993,7 +12993,7 @@
         },
         "execa": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
           "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "requires": {
@@ -13008,7 +13008,7 @@
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
@@ -13017,13 +13017,13 @@
         },
         "get-caller-file": {
           "version": "2.0.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
           "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
           "dev": true
         },
         "get-stream": {
           "version": "4.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
           "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "requires": {
@@ -13032,7 +13032,7 @@
         },
         "hash-base": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
           "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
           "dev": true,
           "requires": {
@@ -13043,7 +13043,7 @@
         },
         "hash.js": {
           "version": "1.1.7",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
           "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
           "dev": true,
           "requires": {
@@ -13053,7 +13053,7 @@
         },
         "hmac-drbg": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
           "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
           "dev": true,
           "requires": {
@@ -13064,43 +13064,43 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
           "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "dev": true
         },
         "invert-kv": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
           "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "is-hex-prefixed": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
           "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
           "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "keccak": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
           "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
           "dev": true,
           "requires": {
@@ -13110,7 +13110,7 @@
         },
         "lcid": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
           "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "dev": true,
           "requires": {
@@ -13119,7 +13119,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
@@ -13129,7 +13129,7 @@
         },
         "map-age-cleaner": {
           "version": "0.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
           "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
           "dev": true,
           "requires": {
@@ -13138,7 +13138,7 @@
         },
         "md5.js": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
           "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
           "dev": true,
           "requires": {
@@ -13149,7 +13149,7 @@
         },
         "mem": {
           "version": "4.3.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
           "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
           "dev": true,
           "requires": {
@@ -13160,43 +13160,43 @@
         },
         "mimic-fn": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
           "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "dev": true
         },
         "minimalistic-assert": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
           "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
           "dev": true
         },
         "minimalistic-crypto-utils": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
           "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
           "dev": true
         },
         "nice-try": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
           "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
           "dev": true
         },
         "node-addon-api": {
           "version": "2.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
           "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
           "dev": true
         },
         "node-gyp-build": {
           "version": "4.2.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
           "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
           "dev": true
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
@@ -13205,7 +13205,7 @@
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
@@ -13214,7 +13214,7 @@
         },
         "os-locale": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
           "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "dev": true,
           "requires": {
@@ -13225,25 +13225,25 @@
         },
         "p-defer": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
           "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
           "dev": true
         },
         "p-finally": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
           "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-is-promise": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
           "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
           "dev": true
         },
         "p-limit": {
           "version": "2.3.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
@@ -13252,7 +13252,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
@@ -13261,25 +13261,25 @@
         },
         "p-try": {
           "version": "2.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "pbkdf2": {
           "version": "3.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
           "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
           "dev": true,
           "requires": {
@@ -13292,7 +13292,7 @@
         },
         "pump": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
@@ -13302,7 +13302,7 @@
         },
         "randombytes": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
           "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
           "dev": true,
           "requires": {
@@ -13311,7 +13311,7 @@
         },
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
@@ -13322,19 +13322,19 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
           "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
           "dev": true
         },
         "ripemd160": {
           "version": "2.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
           "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
           "dev": true,
           "requires": {
@@ -13344,7 +13344,7 @@
         },
         "rlp": {
           "version": "2.2.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
           "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
           "dev": true,
           "requires": {
@@ -13353,19 +13353,19 @@
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
           "dev": true
         },
         "scrypt-js": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
           "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
           "dev": true
         },
         "secp256k1": {
           "version": "4.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
           "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
           "dev": true,
           "requires": {
@@ -13376,25 +13376,25 @@
         },
         "semver": {
           "version": "5.7.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "setimmediate": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
           "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
           "dev": true
         },
         "sha.js": {
           "version": "2.4.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
           "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
           "dev": true,
           "requires": {
@@ -13404,7 +13404,7 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
           "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
@@ -13413,25 +13413,25 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
           "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
           "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
           "dev": true
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
         "source-map-support": {
           "version": "0.5.12",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
           "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
           "dev": true,
           "requires": {
@@ -13441,7 +13441,7 @@
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
@@ -13452,7 +13452,7 @@
         },
         "string_decoder": {
           "version": "1.3.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
           "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "dev": true,
           "requires": {
@@ -13461,7 +13461,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
@@ -13470,13 +13470,13 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
           "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "strip-hex-prefix": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
           "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
           "dev": true,
           "requires": {
@@ -13485,13 +13485,13 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true
         },
         "which": {
           "version": "1.3.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
           "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "requires": {
@@ -13500,13 +13500,13 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "wrap-ansi": {
           "version": "5.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
           "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
           "dev": true,
           "requires": {
@@ -13517,19 +13517,19 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
           "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
         "yargs": {
           "version": "13.2.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
           "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
           "dev": true,
           "requires": {
@@ -13548,7 +13548,7 @@
         },
         "yargs-parser": {
           "version": "13.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -14,18 +14,18 @@
   ],
   "scripts": {
     "prebuild": "rimraf dist && patch-package",
-    "build": "npm run compile:contracts && npm run build:typechain && npm run compile:ts && copyfiles \"typechain/**/*.d.ts\" dist",
+    "build": "npm run compile:contracts && npm run build:typechain && npm run compile:ts && copyfiles \"ethers-v4/**/*.d.ts\" dist",
     "compile:ts": "bili",
     "test": "run-with-testrpc -m \"candy maple cake sugar pudding cream honey rich smooth crumble sweet treat\" --port 8544 --accounts 20 --networkId=9 --gasLimit=10000000 \"npm run test-ganache\" ",
     "ganache": "ganache-cli -m \"candy maple cake sugar pudding cream honey rich smooth crumble sweet treat\" --port 8544 --accounts 20 --networkId=9 --gasLimit=10000000",
     "test-ganache": "mocha -r ts-node/register test/*test.ts",
     "compile:contracts": "truffle compile",
     "build:typechain": "npm run build:typechain:domainnotifier && npm run build:typechain:resolver && npm run build:typechain:registry && npm run build:typechain:publicresolver && npm run build:typechain:claimmanager",
-    "build:typechain:domainnotifier": "typechain --target ethers-v4 --outDir typechain './build/contracts/DomainNotifier.json'",
-    "build:typechain:resolver": "typechain --target ethers-v4 --outDir typechain './build/contracts/RoleDefinitionResolver.json'",
-    "build:typechain:registry": "typechain --target ethers-v4 --outDir typechain './node_modules/@ensdomains/ens/build/contracts/ENSRegistry.json'",
-    "build:typechain:publicresolver": "typechain --target ethers-v4 --outDir typechain './node_modules/@ensdomains/resolver/build/contracts/PublicResolver.json'",
-    "build:typechain:claimmanager": "typechain --target ethers-v4 --outDir typechain './build/contracts/ClaimManager.json'"
+    "build:typechain:domainnotifier": "typechain --target ethers-v4 --outDir ethers-v4 './build/contracts/DomainNotifier.json'",
+    "build:typechain:resolver": "typechain --target ethers-v4 --outDir ethers-v4 './build/contracts/RoleDefinitionResolver.json'",
+    "build:typechain:registry": "typechain --target ethers-v4 --outDir ethers-v4 './node_modules/@ensdomains/ens/build/contracts/ENSRegistry.json'",
+    "build:typechain:publicresolver": "typechain --target ethers-v4 --outDir ethers-v4 './node_modules/@ensdomains/resolver/build/contracts/PublicResolver.json'",
+    "build:typechain:claimmanager": "typechain --target ethers-v4 --outDir ethers-v4 './build/contracts/ClaimManager.json'"
   },
   "homepage": "https://github.com/energywebfoundation/iam-contracts/#readme",
   "repository": {

--- a/src/DomainHierarchy.ts
+++ b/src/DomainHierarchy.ts
@@ -1,15 +1,15 @@
 import { EventFilter, utils, providers } from "ethers";
-import { ENSRegistry } from "../typechain/ENSRegistry";
+import { ENSRegistry } from "../ethers-v4/ENSRegistry";
 import { abi as ensRegistryContract } from "../build/contracts/ENS.json";
 import { abi as ensResolverContract } from "../build/contracts/PublicResolver.json";
 import { abi as domainNotifierContract } from '../build/contracts/DomainNotifier.json';
 import { emptyAddress } from "./constants";
 import { DomainReader } from "./DomainReader";
-import { PublicResolver__factory } from "../typechain/factories/PublicResolver__factory";
-import { DomainNotifier__factory } from "../typechain/factories/DomainNotifier__factory";
+import { PublicResolver__factory } from "../ethers-v4/factories/PublicResolver__factory";
+import { DomainNotifier__factory } from "../ethers-v4/factories/DomainNotifier__factory";
 import { Provider } from "ethers/providers";
-import { PublicResolver } from "../typechain/PublicResolver";
-import { DomainNotifier } from "../typechain/DomainNotifier";
+import { PublicResolver } from "../ethers-v4/PublicResolver";
+import { DomainNotifier } from "../ethers-v4/DomainNotifier";
 
 export class DomainHierarchy {
   protected readonly _domainReader: DomainReader;

--- a/src/DomainReader.ts
+++ b/src/DomainReader.ts
@@ -1,15 +1,15 @@
 import { IAppDefinition, IIssuerDefinition, IOrganizationDefinition, IRoleDefinition, IRoleDefinitionText, PreconditionType } from './types/DomainDefinitions'
 import { VOLTA_CHAIN_ID, VOLTA_PUBLIC_RESOLVER_ADDRESS, VOLTA_RESOLVER_V1_ADDRESS } from "./chainConstants";
-import { ENSRegistry__factory } from "../typechain/factories/ENSRegistry__factory";
+import { ENSRegistry__factory } from "../ethers-v4/factories/ENSRegistry__factory";
 import { Provider } from "ethers/providers";
-import { PublicResolver } from "../typechain/PublicResolver";
-import { PublicResolver__factory } from "../typechain/factories/PublicResolver__factory";
-import { RoleDefinitionResolver } from "../typechain/RoleDefinitionResolver"
+import { PublicResolver } from "../ethers-v4/PublicResolver";
+import { PublicResolver__factory } from "../ethers-v4/factories/PublicResolver__factory";
+import { RoleDefinitionResolver } from "../ethers-v4/RoleDefinitionResolver"
 import { namehash } from "ethers/utils";
-import { RoleDefinitionResolver__factory } from "../typechain/factories/RoleDefinitionResolver__factory";
+import { RoleDefinitionResolver__factory } from "../ethers-v4/factories/RoleDefinitionResolver__factory";
 import { ResolverContractType } from "./types/ResolverContractType";
 import { ERROR_MESSAGES } from "./types/ErrorMessages";
-import { ENSRegistry } from '../typechain/ENSRegistry';
+import { ENSRegistry } from '../ethers-v4/ENSRegistry';
 
 export class DomainReader {
   public static isOrgDefinition = (domainDefinition: IRoleDefinitionText | IOrganizationDefinition | IAppDefinition): domainDefinition is IOrganizationDefinition =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,10 @@ import { VOLTA_CHAIN_ID, VOLTA_DOMAIN_NOTIFER_ADDRESS, VOLTA_ENS_REGISTRY_ADDRES
 import { IAppDefinition, IOrganizationDefinition, IRoleDefinition, IRoleDefinitionText, PreconditionType } from "./types/DomainDefinitions"
 import { ResolverContractType } from "./types/ResolverContractType";
 import { EncodedCall } from "./types/Transaction"
-import { DomainNotifier__factory } from "../typechain/factories/DomainNotifier__factory"
-import { ENSRegistry__factory } from "../typechain/factories/ENSRegistry__factory"
-import { PublicResolver__factory } from "../typechain/factories/PublicResolver__factory"
-import { RoleDefinitionResolver__factory } from "../typechain/factories/RoleDefinitionResolver__factory"
+import { DomainNotifier__factory } from "../ethers-v4/factories/DomainNotifier__factory"
+import { ENSRegistry__factory } from "../ethers-v4/factories/ENSRegistry__factory"
+import { PublicResolver__factory } from "../ethers-v4/factories/PublicResolver__factory"
+import { RoleDefinitionResolver__factory } from "../ethers-v4/factories/RoleDefinitionResolver__factory"
 
 // To disable "WARNING: Multiple definitions for addr" that is triggered by ENS Registry
 errors.setLogLevel("error");

--- a/test/ClaimManagerTests/ClaimManager.testSuit.ts
+++ b/test/ClaimManagerTests/ClaimManager.testSuit.ts
@@ -2,12 +2,12 @@ import { utils, ContractFactory, Signer, Contract, Wallet } from 'ethers';
 import { JsonRpcProvider } from 'ethers/providers';
 import { expect } from 'chai';
 import { abi as erc1056Abi, bytecode as erc1056Bytecode } from './ERC1056.json';
-import { ClaimManager__factory as ClaimManagerFactory } from '../../typechain/factories/ClaimManager__factory';
-import { ClaimManager } from '../../typechain/ClaimManager';
+import { ClaimManager__factory as ClaimManagerFactory } from '../../ethers-v4/factories/ClaimManager__factory';
+import { ClaimManager } from '../../ethers-v4/ClaimManager';
 import { DomainTransactionFactory } from '../../src';
 import { namehash, keccak256, toUtf8Bytes, id } from 'ethers/utils';
-import { ENSRegistry } from '../../typechain/ENSRegistry';
-import { RoleDefinitionResolver } from '../../typechain/RoleDefinitionResolver';
+import { ENSRegistry } from '../../ethers-v4/ENSRegistry';
+import { RoleDefinitionResolver } from '../../ethers-v4/RoleDefinitionResolver';
 import { PreconditionType } from '../../src/types/DomainDefinitions';
 
 const { solidityKeccak256, arrayify, defaultAbiCoder } = utils;

--- a/test/DomainCRUD.testSuite.ts
+++ b/test/DomainCRUD.testSuite.ts
@@ -14,10 +14,10 @@ import {
 import { PreconditionType } from "../src/types/DomainDefinitions";
 import { ERROR_MESSAGES } from "../src/types/ErrorMessages";
 import { LegacyDomainDefTransactionFactory } from "./LegacyDomainDefTransactionFactory";
-import { ENSRegistry } from "../typechain/ENSRegistry";
-import { RoleDefinitionResolver } from "../typechain/RoleDefinitionResolver";
-import { DomainNotifier } from "../typechain/DomainNotifier";
-import { PublicResolver } from "../typechain/PublicResolver";
+import { ENSRegistry } from "../ethers-v4/ENSRegistry";
+import { RoleDefinitionResolver } from "../ethers-v4/RoleDefinitionResolver";
+import { DomainNotifier } from "../ethers-v4/DomainNotifier";
+import { PublicResolver } from "../ethers-v4/PublicResolver";
 import { hashLabel } from "./iam-contracts.test";
 
 chai.use(chaiAsPromised);

--- a/test/DomainHierarchy.testSuite.ts
+++ b/test/DomainHierarchy.testSuite.ts
@@ -1,10 +1,10 @@
 import { ContractFactory } from 'ethers';
 import { DomainHierarchy } from '../src/DomainHierarchy';
 import { DomainReader, DomainTransactionFactory, EncodedCall, IRoleDefinition, ResolverContractType } from '../src';
-import { ENSRegistry } from '../typechain/ENSRegistry';
-import { RoleDefinitionResolver } from '../typechain/RoleDefinitionResolver';
-import { DomainNotifier } from '../typechain/DomainNotifier';
-import { PublicResolver } from '../typechain/PublicResolver';
+import { ENSRegistry } from '../ethers-v4/ENSRegistry';
+import { RoleDefinitionResolver } from '../ethers-v4/RoleDefinitionResolver';
+import { DomainNotifier } from '../ethers-v4/DomainNotifier';
+import { PublicResolver } from '../ethers-v4/PublicResolver';
 import { JsonRpcProvider, JsonRpcSigner } from "ethers/providers";
 import { hashLabel } from './iam-contracts.test';
 import { namehash } from 'ethers/utils';

--- a/test/DomainHierarchy.volta.test.ts
+++ b/test/DomainHierarchy.volta.test.ts
@@ -1,5 +1,5 @@
 import { providers } from 'ethers';
-import { ENSRegistry__factory } from '../typechain/factories/ENSRegistry__factory'
+import { ENSRegistry__factory } from '../ethers-v4/factories/ENSRegistry__factory'
 import { VOLTA_DOMAIN_NOTIFER_ADDRESS, VOLTA_ENS_REGISTRY_ADDRESS, VOLTA_PUBLIC_RESOLVER_ADDRESS } from '../src/chainConstants'
 import { DomainHierarchy } from '../src/DomainHierarchy';
 import { DomainReader } from '../src';

--- a/test/LegacyDomainDefTransactionFactory.ts
+++ b/test/LegacyDomainDefTransactionFactory.ts
@@ -1,5 +1,5 @@
 import { namehash } from "ethers/utils";
-import { PublicResolver } from "../typechain/PublicResolver";
+import { PublicResolver } from "../ethers-v4/PublicResolver";
 import { EncodedCall, IRoleDefinition } from "../src/index";
 
 /**

--- a/test/RoleDefinitionResolver.testSuite.ts
+++ b/test/RoleDefinitionResolver.testSuite.ts
@@ -1,9 +1,9 @@
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { ContractFactory, ContractTransaction, utils } from "ethers";
-import { ENSRegistry } from "../typechain/ENSRegistry";
-import { RoleDefinitionResolver } from "../typechain/RoleDefinitionResolver";
-import { DomainNotifier } from "../typechain/DomainNotifier";
+import { ENSRegistry } from "../ethers-v4/ENSRegistry";
+import { RoleDefinitionResolver } from "../ethers-v4/RoleDefinitionResolver";
+import { DomainNotifier } from "../ethers-v4/DomainNotifier";
 import { JsonRpcSigner } from "ethers/providers";
 import { BigNumber } from "ethers/utils";
 


### PR DESCRIPTION
This is to make it easer to include types for other libraries (e.g. ethers v5) in the future