### PR TITLE
fix(DomainHierarchy): DomainHierarchy accomodate deleted namespaces

### DIFF
--- a/test/DomainHierarchy.volta.test.ts
+++ b/test/DomainHierarchy.volta.test.ts
@@ -10,7 +10,7 @@ const { JsonRpcProvider } = providers;
  * This test suite is to retrieval of the suddomains actually
  * on Volta. Not intended to be run during CI/CD
  */
-xdescribe('[getSubDomains]', async function () {
+xdescribe('[DomainHierarchy VOLTA]', async function () {
   this.timeout(0);
   const provider = new JsonRpcProvider('https://volta-rpc.energyweb.org');
 

--- a/test/iam-contracts.test.ts
+++ b/test/iam-contracts.test.ts
@@ -5,7 +5,7 @@ import { abi as DomainNotifierAbi, bytecode as DomainNotiferBytecode } from '../
 import { abi as ensAbi, bytecode as ensBytecode } from '@ensdomains/ens/build/contracts/ENSRegistry.json';
 import { roleDefinitionResolverTestSuite } from './RoleDefinitionResolver.testSuite';
 import { domainCrudTestSuite } from './DomainCRUD.testSuite';
-import { getSubDomainsTestSuite } from './DomainHierarchy.testSuite';
+import { domainHierarchyTestSuite } from './DomainHierarchy.testSuite';
 import { claimManagerTests } from './ClaimManagerTests/ClaimManager.testSuit';
 
 const { JsonRpcProvider } = providers;
@@ -35,6 +35,6 @@ describe('[IAM CONTRACTS]', function () {
 
   describe('RoleDefinitionResolver Test', roleDefinitionResolverTestSuite);
   describe('DomainCRUD Test', domainCrudTestSuite);
-  describe('getSubDomains Test', getSubDomainsTestSuite);
+  describe('DomainHierarchy Test', domainHierarchyTestSuite);
   describe('ClaimManager Test', claimManagerTests);
 });


### PR DESCRIPTION
SWTCH-997 https://energyweb.atlassian.net/browse/SWTCH-997
Before, if domain was deleted (i.e. not registered on ENS) this cause exception which broke `getSubdomains` methods
Also added tests for `DomainHierarchy.getSubdomainsUsingRegistry()`

