### PR TITLE
feature/ICL-66 publish patron required roles

### DIFF
--- a/contracts/staking/StakingPool.sol
+++ b/contracts/staking/StakingPool.sol
@@ -16,7 +16,7 @@ contract StakingPool {
   event StakeWithdrawalRequested(address indexed patron, uint indexed timestamp);
   event StakeWithdrawn(address indexed patron, uint indexed timestamp);
   
-  uint principal;
+  uint public immutable principal;
   uint public totalStake;
   uint immutable public minStakingPeriod; // seconds
 
@@ -26,7 +26,7 @@ contract StakingPool {
   bytes32[] patronRoles;
   
   address payable immutable rewardPool;
-  uint immutable patronRewardPortion;
+  uint immutable public patronRewardPortion;
   
   mapping(address => Stake) public stakes;
   address[] patrons;
@@ -144,6 +144,10 @@ contract StakingPool {
     else {
       reward = RewardPool(rewardPool).checkReward(stake.amount, stake.depositEnd - stake.depositStart, patronRewardPortion);
     }
+  }
+  
+  function getPatronRoles() public view returns (bytes32[] memory) {
+    return patronRoles;
   }
   
   function addPatron(address _patron) internal {

--- a/contracts/staking/StakingPoolFactory.sol
+++ b/contracts/staking/StakingPoolFactory.sol
@@ -9,9 +9,9 @@ contract StakingPoolFactory {
     address provider;
     address pool;
   }
-  uint immutable principalThreshold;
+  uint immutable public principalThreshold;
   
-  uint immutable withdrawDelay;
+  uint immutable public withdrawDelay;
   
   address immutable claimManager;
   address immutable ensRegistry;


### PR DESCRIPTION
Made constant fields of `StakingPool` and `StakingPoolFactory` public. `patronRoles` needed to verify that patron is authorized to stake and communicate staking requirements to patron. Other constants might be required later 
PR will be merged after https://github.com/energywebfoundation/iam-client-lib/pull/242 is tested