### PR TITLE
build: Add .sol files to the NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "prebuild": "rimraf dist ethers && patch-package",
-    "build": "npm run compile:contracts && npm run build:typechain && npm run compile:ts && copyfiles build/contracts/**/*.json -u 1 dist && copyfiles \"ethers/**/*.d.ts\" dist",
+    "build": "npm run compile:contracts && npm run build:typechain && npm run compile:ts && copyfiles build/contracts/**/*.json -u 1 dist && copyfiles \"ethers/**/*.d.ts\" dist && copyfiles \"contracts/**/*\" -u 1 dist/contracts",
     "compile:ts": "bili",
     "test": "run-with-testrpc -m \"candy maple cake sugar pudding cream honey rich smooth crumble sweet treat\" --port 8544 --accounts 20 --networkId=9 --gasLimit=10000000 \"npm run test-ganache\" ",
     "ganache": "ganache-cli -m \"candy maple cake sugar pudding cream honey rich smooth crumble sweet treat\" --port 8544 --accounts 20 --networkId=9 --gasLimit=10000000",


### PR DESCRIPTION
`.sol` files were missing in the built NPM package.

This command adds the `.sol` files to the final `dist/` folder, and thus the NPM package.

The final `dist/` folder structure looks like this now:

![Screen Shot 2021-09-27 at 16 00 43](https://user-images.githubusercontent.com/9353642/134923629-1af9d7b8-f53a-414b-bed7-e2ac8c05a07e.png)

