### PR TITLE
feature/add commit types

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,28 @@
   "release": {
     "branches": "master",
     "plugins": [
-      "@semantic-release/commit-analyzer",
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "preset": "angular",
+          "releaseRules": [
+            {
+              "type": "docs",
+              "release": "patch"
+            },
+            {
+              "type": "refactor",
+              "release": "minor"
+            },
+            {
+            },
+            {
+              "scope": "build",
+              "release": "patch"
+            }
+          ]
+        }
+      ],
       "@semantic-release/release-notes-generator",
       "@semantic-release/changelog",
       "@semantic-release/npm",


### PR DESCRIPTION
Without additional configuration semantic release triggers release if commit type matches default types - https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js. This PR introduces several types not covered by default types