### PR TITLE
bug/failed semanitc-release analyze commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "@semantic-release/commit-analyzer",
         {
           "preset": "angular",
-          "releaseRules": [
+          "release": [
             {
               "type": "docs",
               "release": "patch"


### PR DESCRIPTION
Although release rules of the semantic-release must be specified under `releaseRules` property, when configuration is defined in package.json semantic-release is looking for `release` property https://github.com/energywebfoundation/iam-contracts/runs/3752397586