### PR TITLE
fix(commit-analyzer): remove empty release rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
               "type": "refactor",
               "release": "minor"
             },
-            {},
             {
               "scope": "build",
               "release": "patch"


### PR DESCRIPTION
This change is motivated by build error here: https://github.com/energywebfoundation/iam-contracts/runs/3791247653?check_suite_focus=true