### PR TITLE
feat(ClaimManager): import V2 of RoleDefResolver

### DIFF
--- a/contracts/roles/ClaimManager.sol
+++ b/contracts/roles/ClaimManager.sol
@@ -8,7 +8,7 @@ import "@ew-did-registry/proxyidentity/contracts/IOwned.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import "./RoleDefinitionResolver.sol";
+import "./RoleDefinitionResolverV2.sol";
 
 interface EthereumDIDRegistry {
   function identityOwner(address identity) external view returns(address);


### PR DESCRIPTION
This is to limit the scope of the audit to RoleDefinitionResolverV2