### PR TITLE
feat(claims): remove deprecated `fields` property

### DIFF
--- a/src/DomainTransactionFactory.ts
+++ b/src/DomainTransactionFactory.ts
@@ -172,7 +172,6 @@ export class DomainTransactionFactory {
       return {
         roleName: roleDef.roleName,
         roleType: roleDef.roleType,
-        fields: roleDef.fields,
         requestorFields: roleDef.requestorFields,
         issuerFields: roleDef.issuerFields,
         metadata: roleDef.metadata,

--- a/src/DomainTransactionFactoryV2.ts
+++ b/src/DomainTransactionFactoryV2.ts
@@ -180,7 +180,6 @@ export class DomainTransactionFactoryV2 {
       return {
         roleName: roleDef.roleName,
         roleType: roleDef.roleType,
-        fields: roleDef.fields,
         requestorFields: roleDef.requestorFields,
         issuerFields: roleDef.issuerFields,
         metadata: roleDef.metadata,

--- a/src/types/DomainDefinitions.ts
+++ b/src/types/DomainDefinitions.ts
@@ -46,7 +46,6 @@ export interface IFieldDefinition {
 export interface IRoleDefinitionText {
   roleType: string;
   roleName: string;
-  fields?: IFieldDefinition[];
   requestorFields?: IFieldDefinition[];
   issuerFields?: IFieldDefinition[];
   metadata: Record<string, unknown> | Record<string, unknown>[];

--- a/test/ClaimManagerTests/ClaimManager.testSuite.ts
+++ b/test/ClaimManagerTests/ClaimManager.testSuite.ts
@@ -200,7 +200,8 @@ function testSuite() {
           roleDefinition: {
             roleName: authorityRole,
             enrolmentPreconditions: [],
-            fields: [],
+            requestorFields: [],
+            issuerFields: [],
             issuer: {
               issuerType: 'DID',
               did: [`did:ethr:volta:${await authority.getAddress()}`],
@@ -224,7 +225,8 @@ function testSuite() {
           roleDefinition: {
             roleName: deviceRole,
             enrolmentPreconditions: [],
-            fields: [],
+            requestorFields: [],
+            issuerFields: [],
             issuer: { issuerType: 'ROLE', roleName: installerRole },
             revoker: { revokerType: 'ROLE', roleName: installerRole },
             metadata: [],
@@ -244,7 +246,8 @@ function testSuite() {
             enrolmentPreconditions: [
               { type: PreconditionType.Role, conditions: [deviceRole] },
             ],
-            fields: [],
+            requestorFields: [],
+            issuerFields: [],
             issuer: { issuerType: 'ROLE', roleName: installerRole },
             revoker: { revokerType: 'ROLE', roleName: installerRole },
             metadata: [],
@@ -262,7 +265,8 @@ function testSuite() {
           roleDefinition: {
             roleName: installerRole,
             enrolmentPreconditions: [],
-            fields: [],
+            issuerFields: [],
+            requestorFields: [],
             issuer: { issuerType: 'ROLE', roleName: authorityRole },
             revoker: { revokerType: 'ROLE', roleName: authorityRole },
             metadata: [],

--- a/test/DomainCRUD.testSuite.ts
+++ b/test/DomainCRUD.testSuite.ts
@@ -27,7 +27,7 @@ const domain = 'mydomain';
 const node = utils.namehash(domain);
 
 const role: IRoleDefinition = {
-  fields: [
+  requestorFields: [
     {
       fieldType: 'myFieldType',
       label: 'myLabel',

--- a/test/DomainCRUD.testSuiteV2.ts
+++ b/test/DomainCRUD.testSuiteV2.ts
@@ -29,7 +29,7 @@ const domain2 = 'mydomain2';
 const node2 = utils.namehash(domain2);
 
 const role2: IRoleDefinitionV2 = {
-  fields: [
+  issuerFields: [
     {
       fieldType: 'myFieldType',
       label: 'myLabel',

--- a/test/DomainHierarchy.testSuite.ts
+++ b/test/DomainHierarchy.testSuite.ts
@@ -70,7 +70,8 @@ const addSubdomain = async (
 };
 
 const role: IRoleDefinitionV2 = {
-  fields: [],
+  requestorFields: [],
+  issuerFields: [],
   issuer: {
     issuerType: 'DID',
     did: [`did:ethr:volta:0x7aA65E31d404A8857BA083f6195757a730b51CFe`],

--- a/test/RevocationRegistry.testSuite.ts
+++ b/test/RevocationRegistry.testSuite.ts
@@ -173,7 +173,8 @@ function testSuite() {
           roleDefinition: {
             roleName: authorityRole,
             enrolmentPreconditions: [],
-            fields: [],
+            requestorFields: [],
+            issuerFields: [],
             issuer: {
               issuerType: 'DID',
               did: [`did:ethr:${await authority.getAddress()}`],
@@ -197,7 +198,8 @@ function testSuite() {
           roleDefinition: {
             roleName: deviceRole,
             enrolmentPreconditions: [],
-            fields: [],
+            requestorFields: [],
+            issuerFields: [],
             issuer: {
               issuerType: 'DID',
               did: [`did:ethr:${await authority.getAddress()}`],
@@ -218,7 +220,8 @@ function testSuite() {
           roleDefinition: {
             roleName: installerRole,
             enrolmentPreconditions: [],
-            fields: [],
+            requestorFields: [],
+            issuerFields: [],
             issuer: { issuerType: 'ROLE', roleName: authorityRole },
             revoker: { revokerType: 'ROLE', roleName: authorityRole },
             metadata: [],
@@ -236,7 +239,8 @@ function testSuite() {
           roleDefinition: {
             roleName: adminRole,
             enrolmentPreconditions: [],
-            fields: [],
+            requestorFields: [],
+            issuerFields: [],
             issuer: { issuerType: 'ROLE', roleName: authorityRole },
             revoker: { revokerType: 'DID', did: [] },
             metadata: [],


### PR DESCRIPTION
BREAKING CHANGE: deprecated `fields` property removed. Use `requestorFields` instead.